### PR TITLE
Add a little specificity to the harm clause

### DIFF
--- a/content/version/1/0/license.md
+++ b/content/version/1/0/license.md
@@ -4,7 +4,7 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 
 * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-* The software may not be used by individuals, corporations, governments, or other groups for systems or activities that actively and knowingly endanger, harm, or otherwise threaten the physical, mental, economic, or general well-being of other individuals or groups.
+* The software may not be used by individuals, corporations, governments, or other groups for systems or activities that actively and knowingly endanger, harm, or otherwise threaten the physical, mental, economic, or general well-being of marginalized individuals or groups.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 

--- a/content/version/1/0/license.md
+++ b/content/version/1/0/license.md
@@ -4,7 +4,7 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 
 * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-* The software may not be used by individuals, corporations, governments, or other groups for systems or activities that actively and knowingly endanger, harm, or otherwise threaten the physical, mental, economic, or general well-being of marginalized individuals or groups.
+* The software may not be used by individuals, corporations, governments, or other groups for systems or activities that actively and knowingly endanger, harm, or otherwise threaten the physical, mental, economic, or general well-being of underprivileged individuals or groups.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 


### PR DESCRIPTION
There is the potential to maliciously misinterpret the harm clause in order to protect groups in power.
As it stands, it could be interpreted as a clause against "punching," not against specifically "punching down," which I believe its intent.

This change makes it a little more difficult to maliciously interpret the harm clause to protect groups in power.