### PR TITLE
Add Animus to list of adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -1,2 +1,3 @@
 Hippocratic License, https://github.com/ContributorCovenant/hippocratic-license
 rack-read_only,https://rubygems.org/gems/rack-read_only
+Animus, https://github.com/SplittyDev/Animus


### PR DESCRIPTION
Since Animus is an educational malware, I think the Hippocratic license can do a lot of good here.