### PR TITLE
add logitechd, dbus-objects and python-install to adopters list

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -19,3 +19,6 @@ suo, https://github.com/dieseltravis/suo
 TidyBlocks, http://tidyblocks.tech
 VCR, https://github.com/vcr/vcr
 zip_tricks, https://github.com/wetransfer/zip_tricks
+logitechd, https://github.com/FFY00/logitechd
+dbus-objects, https://github.com/FFY00/dbus-objects
+python-install, https://github.com/FFY00/python-install


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>