### PR TITLE
adopters: remove dbus-objects

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -3,7 +3,6 @@ Animus, https://github.com/SplittyDev/Animus
 cachish, https://github.com/thusoy/cachish
 DCAN, https://github.com/DecentralizedCAN/CAN
 DimeNet, https://github.com/klicperajo/dimenet
-dbus-objects, https://github.com/FFY00/dbus-objects
 FODA Card Game, https://github.com/rafaelcastrocouto/foda
 format_parser, https://rubygems.org/gems/format_parser
 Functional Programming for Mortals with Cats in Scala (book), https://leanpub.com/fpmortals-cats


### PR DESCRIPTION
Unfortunately, after a few users raised concern about the enforcability
of this license I had to remove it.

I think the main concern is about the legalese included in the license
and users not feeling comfortable enough to use it. Point 3 of
'Compliance with Human Rights Principles and Human Rights Laws.' comes
to mind. For eg, from my interpretation the Licensee shouldn't be
forced to indemnify the Licensor if someone makes a violation claim
agaisnt them, just in the case they are found to be in violation. But
this is not nessarily clear. I even think there is a possibility for my
interpretation to be incorrect.

Signed-off-by: Filipe Laíns <lains@riseup.net>