### PR TITLE
Add ghost_adapter to adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -6,6 +6,7 @@ DimeNet, https://github.com/klicperajo/dimenet
 FODA Card Game, https://github.com/rafaelcastrocouto/foda
 format_parser, https://rubygems.org/gems/format_parser
 Functional Programming for Mortals with Cats in Scala (book), https://leanpub.com/fpmortals-cats
+ghost_adapter, https://github.com/wetransfer/ghost_adapter
 Gryphon, https://github.com/vinivendra/Gryphon
 Honeycomb Serilog Sink, https://github.com/evilpilaf/HoneycombSerilogSink
 Initiative Solidaires, http://initiativessolidaires.fr


### PR DESCRIPTION
Adds https://github.com/wetransfer/ghost_adapter to the list of adopters.