### PR TITLE
Opt out of Federated Learning of Cohorts

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,3 @@
+/*
+  # Block Google FLoC
+  Permissions-Policy: interest-cohort=()


### PR DESCRIPTION
Add the `Permissions-Policy: interest-cohort=()` HTTP response header to opt out of participation in Google FLoC on firstdonoharm.dev.

```
$ curl -I https://deploy-preview-67--firstdonoharm.netlify.app/
HTTP/2 200
cache-control: public, max-age=0, must-revalidate
content-length: 0
content-type: text/html; charset=UTF-8
date: Wed, 05 May 2021 04:46:43 GMT
etag: "8bc063699bd717e9350628f17856003c-ssl"
permissions-policy: interest-cohort=() <--------- Here it is!
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-language:
server: Netlify
x-nf-request-id: bf2b67c0-5f8e-4e40-8e2d-1c37c9723860
age: 0
x-country: US
x-robots-tag: noindex
```