### PR TITLE
Remove google analytics

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -53,8 +53,5 @@
         </p>
       </footer>
     </div>
-    {{ if not .Site.BuildDrafts }}
-      {{ template "_internal/google_analytics_async.html" . }}
-    {{ end }}
   </body>
 </html>


### PR DESCRIPTION
Missed this when we were removing client-side analytics across our sites. Thanks to [realpixelcode](https://github.com/realpixelcode) for bringing this up in #89 